### PR TITLE
chore: add basic GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a problem so we can improve awesome-md-to-pdf
+title: "[Bug]: "
+labels: [bug, needs-triage]
+assignees: []
+---
+
+## Summary
+A clear and concise description of the problem.
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS: [e.g. Ubuntu 24.04, macOS 15, Windows 11]
+- Node.js: [e.g. 22.14.0]
+- Package version: [e.g. 0.4.0]
+- Installation method: [npm global, npx, local project dependency]
+
+## Input/Command Used
+```bash
+awesome-md-to-pdf input.md -o output.pdf
+```
+
+## Logs / Error Output
+Paste relevant logs, stack traces, or screenshots.
+
+```text
+<logs here>
+```
+
+## Minimal Reproducible Markdown (if applicable)
+```markdown
+# Sample
+A minimal markdown file that reproduces the issue.
+```
+
+## Additional Context
+Add anything else that might help (theme/design mode, CI environment, etc.).
+
+## Checklist
+- [ ] I searched existing issues and did not find a duplicate.
+- [ ] I can reproduce this with the latest version.
+- [ ] I included enough details for someone else to reproduce.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/behl1anmol/awesome-md-to-pdf#readme
+    about: Check the README first, then open an issue if you found a bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for awesome-md-to-pdf
+title: "[Feature]: "
+labels: [enhancement, needs-triage]
+assignees: []
+---
+
+## Problem / Use Case
+What problem are you trying to solve, or what outcome do you want?
+
+## Proposed Solution
+Describe the change you would like to see.
+
+## Alternatives Considered
+Describe any alternative solutions or workarounds you considered.
+
+## Example Usage
+If possible, show what usage might look like.
+
+```bash
+awesome-md-to-pdf input.md -o output.pdf --your-new-option
+```
+
+## Scope and Impact
+Who benefits from this, and how would it improve their workflow?
+
+## Additional Context
+Add mockups, references, links, or related issues.
+
+## Checklist
+- [ ] I searched existing issues and did not find a duplicate.
+- [ ] This request is specific and actionable.
+- [ ] I explained the problem and expected benefit.


### PR DESCRIPTION
## What
Adds neat, basic, and complete GitHub issue templates.

## Changes
- Adds `.github/ISSUE_TEMPLATE/bug_report.md`
- Adds `.github/ISSUE_TEMPLATE/feature_request.md`
- Adds `.github/ISSUE_TEMPLATE/config.yml`
- Disables blank issues and points help requests to the README

## Why
This makes incoming issues more actionable by collecting structured triage details for bugs and clear value-oriented proposals for feature requests.