### PR TITLE
Fix REPL suggestion rendering and ANSI-aware width calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awesome-md-to-pdf",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awesome-md-to-pdf",
-      "version": "0.2.0-beta.3",
+      "version": "0.2.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@vscode/markdown-it-katex": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-md-to-pdf",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "Awesome editorial Markdown → PDF. Convert Markdown files in a directory to beautifully styled PDFs (Claude/Anthropic-inspired design) with mermaid, code highlighting, math, and more.",
   "bin": {
     "awesome-md-to-pdf": "bin/awesome-md-to-pdf.js",

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -483,6 +483,7 @@ class ReplUi {
     // Always clear first, then paint.
     this.clearDropdown();
     if (matches.length === 0) return;
+    this.refreshReadlineLine();
 
     const inputCol = this.currentInputCol();
 
@@ -533,15 +534,30 @@ class ReplUi {
 
   private clearDropdown(): void {
     if (this.suggestionsDrawn === 0) return;
+    this.refreshReadlineLine();
     const inputCol = this.currentInputCol();
-    // Step one row below the prompt and wipe downward.
-    readline.moveCursor(process.stdout, -inputCol, 1);
+    // Step to column 0 on the prompt row, clear each drawn suggestion row
+    // explicitly, then return to the live input column.
     readline.cursorTo(process.stdout, 0);
-    readline.clearScreenDown(process.stdout);
-    // Back up to the original prompt row at the input column.
-    readline.moveCursor(process.stdout, 0, -1);
+    for (let i = 0; i < this.suggestionsDrawn; i++) {
+      readline.moveCursor(process.stdout, 0, 1);
+      readline.cursorTo(process.stdout, 0);
+      readline.clearLine(process.stdout, 0);
+    }
+    readline.moveCursor(process.stdout, 0, -this.suggestionsDrawn);
     readline.cursorTo(process.stdout, inputCol);
     this.suggestionsDrawn = 0;
+  }
+
+  /**
+   * Ask readline to redraw the canonical prompt+buffer line so all subsequent
+   * cursor math starts from the real prompt anchor.
+   */
+  private refreshReadlineLine(): void {
+    const rl = this.rl as unknown as { _refreshLine?: () => void };
+    if (typeof rl._refreshLine === 'function') {
+      rl._refreshLine();
+    }
   }
 
   private applyCompletion(cmd: CommandMeta): void {
@@ -618,8 +634,59 @@ function renderDropdownRow(m: CommandMeta, selected: boolean): string {
 
 /** Strip ANSI escape sequences to measure the terminal-visible width. */
 function visibleLen(s: string): number {
+  // Strip ANSI CSI/OSC sequences before measuring visible cell width.
+  return unicodeCellWidth(stripAnsi(s));
+}
+
+function stripAnsi(s: string): string {
+  // CSI: ESC [ ... command
   // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*m/g, '').length;
+  const noCsi = s.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
+  // OSC: ESC ] ... BEL or ESC \
+  // eslint-disable-next-line no-control-regex
+  return noCsi.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+}
+
+function unicodeCellWidth(input: string): number {
+  let width = 0;
+  for (const ch of input) {
+    width += codePointCellWidth(ch.codePointAt(0) ?? 0);
+  }
+  return width;
+}
+
+function codePointCellWidth(cp: number): number {
+  // C0/C1 controls and DEL.
+  if (cp === 0 || cp < 32 || (cp >= 0x7f && cp < 0xa0)) return 0;
+  // Combining marks.
+  if (
+    (cp >= 0x300 && cp <= 0x36f) ||
+    (cp >= 0x1ab0 && cp <= 0x1aff) ||
+    (cp >= 0x1dc0 && cp <= 0x1dff) ||
+    (cp >= 0x20d0 && cp <= 0x20ff) ||
+    (cp >= 0xfe20 && cp <= 0xfe2f)
+  ) {
+    return 0;
+  }
+  // Wide/full-width ranges (common terminal behavior).
+  if (
+    (cp >= 0x1100 && cp <= 0x115f) ||
+    cp === 0x2329 ||
+    cp === 0x232a ||
+    (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+    (cp >= 0xac00 && cp <= 0xd7a3) ||
+    (cp >= 0xf900 && cp <= 0xfaff) ||
+    (cp >= 0xfe10 && cp <= 0xfe19) ||
+    (cp >= 0xfe30 && cp <= 0xfe6f) ||
+    (cp >= 0xff00 && cp <= 0xff60) ||
+    (cp >= 0xffe0 && cp <= 0xffe6) ||
+    (cp >= 0x1f300 && cp <= 0x1f64f) ||
+    (cp >= 0x1f900 && cp <= 0x1f9ff) ||
+    (cp >= 0x20000 && cp <= 0x3fffd)
+  ) {
+    return 2;
+  }
+  return 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -675,6 +742,12 @@ function printWelcome(): void {
  * the prompt are left behind as visual debris.
  */
 function renderYouBubble(line: string, prompt: string): void {
+  // Normalize terminal state aggressively before drawing the bubble so
+  // stale suggestion text cannot survive to the right of the chat turn.
+  readline.cursorTo(process.stdout, 0);
+  readline.clearLine(process.stdout, 0);
+  readline.clearScreenDown(process.stdout);
+
   const cols = process.stdout.columns || 80;
   const totalLen = visibleLen(prompt) + line.length;
   const rows = Math.max(1, Math.ceil(totalLen / cols));

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -413,8 +413,10 @@ class ReplUi {
   }
 
   private redraw(matches: CommandMeta[]): void {
-    this.drawGhost(matches);
+    // Draw dropdown first because it may call readline _refreshLine(), which
+    // erases any ghost hint currently painted after the input buffer.
     this.drawDropdown(matches);
+    this.drawGhost(matches);
   }
 
   // --- Ghost hint --------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent stale suggestion text and cursor misplacement when drawing/clearing the REPL dropdown and chat "you" bubble, especially across wrapped lines.  
- Accurately measure visible string widths when input contains ANSI color codes or wide/unicode characters so UI alignment is correct.

### Description
- Added `refreshReadlineLine()` to force readline to redraw the canonical prompt+buffer and call it from `drawDropdown` and `clearDropdown`.  
- Reworked `clearDropdown()` to explicitly clear each drawn suggestion row and restore the cursor instead of using `clearScreenDown`, improving cursor math robustness.  
- Replaced the simple length-based `visibleLen` with ANSI-aware and Unicode cell-width aware functions: `stripAnsi()`, `unicodeCellWidth()`, and `codePointCellWidth()` to compute accurate terminal-visible widths.  
- Normalized terminal state before rendering the "you" bubble by clearing the current line and screen to avoid leftover suggestion artifacts.

### Testing
- No automated tests were added for these UI rendering changes.  
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0604dbc6c832abfddc8a747cc4ff4)